### PR TITLE
Bit more secure configuration

### DIFF
--- a/systemvm/patches/debian/config/etc/apache2/httpd.conf
+++ b/systemvm/patches/debian/config/etc/apache2/httpd.conf
@@ -1,2 +1,2 @@
-SSLProtocol -ALL +SSLv3 +TLSv1
-SSLCipherSuite ALL:!aNULL:!ADH:!eNULL:!LOW:!EXP:RC4+RSA:+HIGH:+MEDIUM
+SSLProtocol All -SSLv2 -SSLv3
+SSLCipherSuite AES:!kRSA:!aNULL


### PR DESCRIPTION
SSLv3 should not be used anymore. I included Cipher Suite that support Perfect Forward Security by not allowing anything that doesn't use Diffie-Hellman key exchange.